### PR TITLE
Fix keywords in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,14 +6,7 @@ edition = "2024"
 description = "An event-sourcing library for Rust projects."
 repository = "https://github.com/jwilger/mneme"
 license = "MIT"
-keywords = [
-  "data",
-  "events",
-  "event-sourcing",
-  "cqrs",
-  "eventstoredb",
-  "kurrent",
-]
+keywords = ["events", "event-sourcing", "cqrs", "eventstoredb", "kurrent"]
 
 [badges]
 maintenance = { status = "actively-developed" }


### PR DESCRIPTION
Apparently crates.io will reject if there are more than 5 keywords.