### PR TITLE
Fix version number, bump to 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "mneme"
-version = "0.4.0"
+version = "0.4.2"
 dependencies = [
  "bytes",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mneme"
-version = "0.4.0"
+version = "0.4.2"
 authors = ["John Wilger <john@johnwilger.com>"]
 edition = "2024"
 description = "An event-sourcing library for Rust projects."


### PR DESCRIPTION
The 0.4.1 release was using 0.4.0 in Cargo.toml.