### PR TITLE
Clean up traits for execute args

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -3,7 +3,7 @@ use crate::event::Event;
 use crate::event_store::EventStreamId;
 use std::fmt::Debug;
 
-pub trait Command<E: Event> {
+pub trait Command<E: Event>: Clone {
     type State: AggregateState<E>;
     type Error: std::error::Error + Send + Sync + 'static;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,8 @@ pub async fn execute<E, C, S>(
 ) -> Result<(), Error>
 where
     E: Event,
-    C: Command<E> + Clone + Send,
-    S: EventStore + Send,
+    C: Command<E>,
+    S: EventStore,
 {
     let mut retries = 0;
     let mut command = command;


### PR DESCRIPTION
Remove unnecessary Send trait from the command and event_store args, and add the requirement for the Clone trait on command to the Command trait itself. This makes implementation in the client system a bit easier.