### PR TITLE
Improved devex ergonomics

### DIFF
--- a/src/command.rs
+++ b/src/command.rs
@@ -13,7 +13,7 @@ pub trait Command<E: Event>: Clone {
 
     fn get_state(&self) -> Self::State;
 
-    fn set_state(&self, state: Self::State) -> Self;
+    fn set_state(&mut self, state: Self::State);
 
     fn mark_retry(&self) -> Self
     where
@@ -26,11 +26,11 @@ pub trait Command<E: Event>: Clone {
         None
     }
 
-    fn apply(&mut self, event: E) -> Self
+    fn apply(&mut self, event: &E)
     where
         Self: Sized,
     {
-        self.set_state(self.get_state().apply(event))
+        self.set_state(self.get_state().apply(event));
     }
 }
 
@@ -45,14 +45,14 @@ impl<E: Event> Command<E> for () {
         EventStreamId::new()
     }
     fn get_state(&self) -> Self::State {}
-    fn set_state(&self, _: Self::State) -> Self {}
+    fn set_state(&mut self, _: Self::State) {}
     fn mark_retry(&self) -> Self {}
 }
 
 pub trait AggregateState<E: Event>: Debug + Sized {
-    fn apply(&self, event: E) -> Self;
+    fn apply(&self, event: &E) -> Self;
 }
 
 impl<E: Event> AggregateState<E> for () {
-    fn apply(&self, _: E) {}
+    fn apply(&self, _: &E) {}
 }

--- a/src/command.rs
+++ b/src/command.rs
@@ -3,11 +3,12 @@ use crate::event::Event;
 use crate::event_store::EventStreamId;
 use std::fmt::Debug;
 
-pub trait Command<E: Event>: Clone {
-    type State: AggregateState<E>;
+pub trait Command: Clone {
+    type Event: Event;
+    type State: AggregateState<Self::Event>;
     type Error: std::error::Error + Send + Sync + 'static;
 
-    fn handle(&self) -> Result<Vec<E>, Self::Error>;
+    fn handle(&self) -> Result<Vec<Self::Event>, Self::Error>;
 
     fn event_stream_id(&self) -> EventStreamId;
 
@@ -26,27 +27,12 @@ pub trait Command<E: Event>: Clone {
         None
     }
 
-    fn apply(&mut self, event: &E)
+    fn apply(&mut self, event: &Self::Event)
     where
         Self: Sized,
     {
         self.set_state(self.get_state().apply(event));
     }
-}
-
-impl<E: Event> Command<E> for () {
-    type State = ();
-    type Error = std::convert::Infallible;
-
-    fn handle(&self) -> Result<Vec<E>, Self::Error> {
-        Ok(vec![])
-    }
-    fn event_stream_id(&self) -> EventStreamId {
-        EventStreamId::new()
-    }
-    fn get_state(&self) -> Self::State {}
-    fn set_state(&mut self, _: Self::State) {}
-    fn mark_retry(&self) -> Self {}
 }
 
 pub trait AggregateState<E: Event>: Debug + Sized {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,7 +20,7 @@ pub async fn execute<E, C, S>(
 ) -> Result<(), Error>
 where
     E: Event,
-    C: Command<E>,
+    C: Command<Event = E>,
     S: EventStore,
 {
     let mut retries = 0;
@@ -168,7 +168,8 @@ mod tests {
         }
     }
 
-    impl Command<TestEvent> for AlwaysConflictingCommand {
+    impl Command for AlwaysConflictingCommand {
+        type Event = TestEvent;
         type State = ();
         type Error = Error;
 
@@ -324,7 +325,8 @@ mod tests {
         state: StatefulCommandState,
     }
 
-    impl Command<TestEvent> for ConcurrentModificationCommand {
+    impl Command for ConcurrentModificationCommand {
+        type Event = TestEvent;
         type State = StatefulCommandState;
         type Error = Error;
 
@@ -459,7 +461,8 @@ mod tests {
         id: Uuid,
     }
 
-    impl Command<TestEvent> for EventProducingCommand {
+    impl Command for EventProducingCommand {
+        type Event = TestEvent;
         type State = ();
         type Error = Infallible;
 

--- a/tests/test_cases.rs
+++ b/tests/test_cases.rs
@@ -32,9 +32,7 @@ impl Command<()> for NoopCommand {
         EventStreamId(self.id)
     }
     fn get_state(&self) -> Self::State {}
-    fn set_state(&self, _: Self::State) -> Self {
-        (*self).clone()
-    }
+    fn set_state(&mut self, _: Self::State) {}
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -63,9 +61,7 @@ impl Command<()> for RejectCommand {
         EventStreamId(self.id)
     }
     fn get_state(&self) -> Self::State {}
-    fn set_state(&self, _: Self::State) -> Self {
-        (*self).clone()
-    }
+    fn set_state(&mut self, _: Self::State) {}
 }
 
 #[derive(Clone)]
@@ -93,9 +89,7 @@ impl Command<TestEvent> for EventProducingCommand {
         EventStreamId(self.id)
     }
     fn get_state(&self) -> Self::State {}
-    fn set_state(&self, _: Self::State) -> Self {
-        (*self).clone()
-    }
+    fn set_state(&mut self, _: Self::State) {}
 }
 
 #[derive(Clone, Debug)]
@@ -105,14 +99,14 @@ pub struct StatefulCommandState {
 }
 
 impl AggregateState<TestEvent> for StatefulCommandState {
-    fn apply(&self, event: TestEvent) -> Self {
+    fn apply(&self, event: &TestEvent) -> Self {
         match event {
             TestEvent::FooHappened { value, .. } => Self {
-                foo: Some(value),
+                foo: Some(*value),
                 ..*self
             },
             TestEvent::BarHappened { value, .. } => Self {
-                bar: Some(value),
+                bar: Some(*value),
                 ..*self
             },
             _ => Self { ..*self },
@@ -146,10 +140,8 @@ impl Command<TestEvent> for StatefulCommand {
         self.state.clone()
     }
 
-    fn set_state(&self, state: Self::State) -> Self {
-        let mut new = (*self).clone();
-        new.state = state;
-        new
+    fn set_state(&mut self, state: Self::State) {
+        self.state = state;
     }
 
     fn event_stream_id(&self) -> EventStreamId {

--- a/tests/test_cases.rs
+++ b/tests/test_cases.rs
@@ -21,7 +21,8 @@ impl NoopCommand {
     }
 }
 
-impl Command<()> for NoopCommand {
+impl Command for NoopCommand {
+    type Event = ();
     type State = ();
     type Error = Infallible;
 
@@ -50,7 +51,8 @@ impl RejectCommand {
     }
 }
 
-impl Command<()> for RejectCommand {
+impl Command for RejectCommand {
+    type Event = ();
     type State = ();
     type Error = RejectCommandError;
 
@@ -75,7 +77,8 @@ impl EventProducingCommand {
     }
 }
 
-impl Command<TestEvent> for EventProducingCommand {
+impl Command for EventProducingCommand {
+    type Event = TestEvent;
     type State = ();
     type Error = Infallible;
 
@@ -132,7 +135,8 @@ impl StatefulCommand {
     }
 }
 
-impl Command<TestEvent> for StatefulCommand {
+impl Command for StatefulCommand {
+    type Event = TestEvent;
     type State = StatefulCommandState;
     type Error = Infallible;
 


### PR DESCRIPTION
This pull request refactors the `Command` trait and its implementations to improve type safety and consistency. The changes include modifying the trait to use an associated type for events, updating method signatures, and adjusting implementations accordingly.

Key changes include:

### Trait Refactoring:
* The `Command` trait now uses an associated type `Event` instead of a generic parameter, which simplifies the trait's usage and improves type safety. (`src/command.rs`, `[[1]](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL6-R17)`, `[[2]](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL29-R43)`)
* The `AggregateState` trait's `apply` method now takes a reference to the event instead of consuming it, which aligns with the new `Command` trait. (`src/command.rs`, `[src/command.rsL29-R43](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL29-R43)`)

### Method Signature Updates:
* Updated the `handle` and `apply` methods in the `Command` trait to use the associated `Event` type. (`src/command.rs`, `[src/command.rsL6-R17](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL6-R17)`)
* Changed the `set_state` method to take a mutable reference to `self` instead of consuming `self`. (`src/command.rs`, `[src/command.rsL6-R17](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL6-R17)`)

### Implementation Adjustments:
* Updated various implementations of the `Command` trait in the test cases to match the new trait definition. (`src/lib.rs`, `[[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L171-R177)`, `[[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L329-R338)`, `[[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L466-R465)`, `tests/test_cases.rs`, `[[4]](diffhunk://#diff-4300fcbb75cb722103f54594a5422baf31a5e7753a5ad32e7f9eb2ecdf9b8c83L24-R25)`, `[[5]](diffhunk://#diff-4300fcbb75cb722103f54594a5422baf31a5e7753a5ad32e7f9eb2ecdf9b8c83L55-R55)`, `[[6]](diffhunk://#diff-4300fcbb75cb722103f54594a5422baf31a5e7753a5ad32e7f9eb2ecdf9b8c83L82-R81)`, `[[7]](diffhunk://#diff-4300fcbb75cb722103f54594a5422baf31a5e7753a5ad32e7f9eb2ecdf9b8c83L141-R148)`)
* Adjusted the `apply` method in `AggregateState` implementations to match the new signature. (`src/lib.rs`, `[[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L383-R388)`, `tests/test_cases.rs`, `[[2]](diffhunk://#diff-4300fcbb75cb722103f54594a5422baf31a5e7753a5ad32e7f9eb2ecdf9b8c83L108-R112)`)

### Function Signature Updates:
* Updated the `execute` function to use the new `Command` trait definition with the associated `Event` type. (`src/lib.rs`, `[[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L23-R23)`, `[[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L48-R48)`)