### PR TITLE
Use references to mutable state in commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1090,7 +1090,7 @@ dependencies = [
 
 [[package]]
 name = "mneme"
-version = "0.4.2"
+version = "0.5.0"
 dependencies = [
  "bytes",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mneme"
-version = "0.4.2"
+version = "0.5.0"
 authors = ["John Wilger <john@johnwilger.com>"]
 edition = "2024"
 description = "An event-sourcing library for Rust projects."

--- a/src/command.rs
+++ b/src/command.rs
@@ -14,7 +14,7 @@ pub trait Command: Clone {
 
     fn get_state(&self) -> Self::State;
 
-    fn set_state(&mut self, state: Self::State);
+    fn set_state(&mut self, state: &Self::State);
 
     fn mark_retry(&self) -> Self
     where
@@ -36,9 +36,11 @@ pub trait Command: Clone {
 }
 
 pub trait AggregateState<E: Event>: Debug + Sized {
-    fn apply(&self, event: &E) -> Self;
+    fn apply(&mut self, event: &E) -> &Self;
 }
 
 impl<E: Event> AggregateState<E> for () {
-    fn apply(&self, _: &E) {}
+    fn apply(&mut self, _: &E) -> &Self {
+        self
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,7 +174,7 @@ mod tests {
         type Error = Error;
 
         fn get_state(&self) -> Self::State {}
-        fn set_state(&mut self, _: Self::State) {}
+        fn set_state(&mut self, _: &Self::State) {}
         fn event_stream_id(&self) -> EventStreamId {
             EventStreamId(self.id)
         }
@@ -334,8 +334,8 @@ mod tests {
             self.state.clone()
         }
 
-        fn set_state(&mut self, state: Self::State) {
-            self.state = state;
+        fn set_state(&mut self, state: &Self::State) {
+            self.state = state.to_owned();
         }
 
         fn event_stream_id(&self) -> EventStreamId {
@@ -378,18 +378,17 @@ mod tests {
     }
 
     impl AggregateState<TestEvent> for StatefulCommandState {
-        fn apply(&self, event: &TestEvent) -> Self {
+        fn apply(&mut self, event: &TestEvent) -> &Self {
             match event {
-                TestEvent::FooHappened { value, .. } => Self {
-                    foo: Some(*value),
-                    ..*self
-                },
-                TestEvent::BarHappened { value, .. } => Self {
-                    bar: Some(*value),
-                    ..*self
-                },
-                _ => Self { ..*self },
+                TestEvent::FooHappened { value, .. } => {
+                    self.foo = Some(*value);
+                }
+                TestEvent::BarHappened { value, .. } => {
+                    self.bar = Some(*value);
+                }
+                _ => (),
             }
+            self
         }
     }
     #[tokio::test]
@@ -476,7 +475,7 @@ mod tests {
             EventStreamId(self.id)
         }
         fn get_state(&self) -> Self::State {}
-        fn set_state(&mut self, _: Self::State) {}
+        fn set_state(&mut self, _: &Self::State) {}
     }
 
     #[tokio::test]


### PR DESCRIPTION
This pull request includes several changes to the `mneme` Rust project, focusing on updating method signatures and improving state handling. The most important changes include modifying the `set_state` method to take a reference and updating the `apply` method to return a reference to `self`.

Version update:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3): Updated the version of the `mneme` package from `0.4.2` to `0.5.0`.

Method signature updates:
* [`src/command.rs`](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL17-R17): Changed the `set_state` method in the `Command` trait to take a reference to `Self::State`.
* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L177-R177): Updated the `set_state` methods in test implementations to take a reference to `Self::State`. [[1]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L177-R177) [[2]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L337-R338) [[3]](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L479-R478)
* [`tests/test_cases.rs`](diffhunk://#diff-4300fcbb75cb722103f54594a5422baf31a5e7753a5ad32e7f9eb2ecdf9b8c83L36-R36): Modified the `set_state` methods in various command implementations to take a reference to `Self::State`. [[1]](diffhunk://#diff-4300fcbb75cb722103f54594a5422baf31a5e7753a5ad32e7f9eb2ecdf9b8c83L36-R36) [[2]](diffhunk://#diff-4300fcbb75cb722103f54594a5422baf31a5e7753a5ad32e7f9eb2ecdf9b8c83L66-R66) [[3]](diffhunk://#diff-4300fcbb75cb722103f54594a5422baf31a5e7753a5ad32e7f9eb2ecdf9b8c83L95-R95) [[4]](diffhunk://#diff-4300fcbb75cb722103f54594a5422baf31a5e7753a5ad32e7f9eb2ecdf9b8c83L147-R147)

State handling improvements:
* [`src/command.rs`](diffhunk://#diff-de6b9cfd1a256da7900d35e26aa7279bd713110e68e91b52616befb7397848dfL39-R45): Updated the `apply` method in the `AggregateState` trait to return a reference to `self` and modified the implementation for the unit type.
* [`src/lib.rs`](diffhunk://#diff-b1a35a68f14e696205874893c07fd24fdb88882b47c23cc0e0c80a30c7d53759L381-R391): Changed the `apply` method in the `StatefulCommandState` implementation to return a reference to `self`.
* [`tests/test_cases.rs`](diffhunk://#diff-4300fcbb75cb722103f54594a5422baf31a5e7753a5ad32e7f9eb2ecdf9b8c83L105-R115): Updated the `apply` method in the `StatefulCommandState` implementation to return a reference to `self`.